### PR TITLE
Copy the _ping.php file in place BEFORE installing when doing build new

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -80,8 +80,8 @@ commands:
     - backup
     - purge
     - finalize
-    - install
     - shell: cp conf/_ping.php current
+    - install
 
 
   # Basic site update functionality


### PR DESCRIPTION
- this is to prevent ending up with a current folder without a _ping.php when the installation fails for some reason in build.sh new.